### PR TITLE
merge[#5]: Feature/microservice-mock a develop

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+MOCK_RESPONSE_TYPE=success

--- a/Services/mock/mock_app/mock.py
+++ b/Services/mock/mock_app/mock.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+import os
+import uvicorn
+
+app = FastAPI()
+
+@app.get("/mock-response")
+def mock_response():
+    response_type = os.getenv("MOCK_RESPONSE_TYPE", "success")
+
+    if response_type == "error":
+        return JSONResponse(
+            status_code=500, 
+            content={"error": "Simulated error response"}
+        )
+    else:
+        return {
+            "user_id": 123,
+            "status": "active",
+            "message": "Simulated success response"
+        }
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=5001)

--- a/Services/mock/requirements.txt
+++ b/Services/mock/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.0
+uvicorn==0.29.0


### PR DESCRIPTION
Este pull request introduce la implementacion del servicio mock solicitado en el issue #5  para emular el comportamiento basico de una API externa

Cambios Incluidos:
- [x] Creacion del endpoint /mock-response: Este endpoint ahora simula respuestas exitosas con un codigo 200 y datos JSON predefinidos, tal como se especifica en el primer criterio de aceptacion

- [x] Manejo de errores simulados: Se ha añadido la funcionalidad para que el mock retorne un codigo 500 y un mensaje de error JSON cuando la variable de entorno MOCK_RESPONSE_TYPE se configura como error, cubriendo así el segundo criterio de aceptacion

Logrando cumplir con lo requerido en el issue #5 